### PR TITLE
removing demo's sticky nav container to fix alignment

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,11 +32,9 @@
 
 	<nav>
 		<div id="sticky">
-			<div class="container">
-				<nav data-autogenerate="true">
-					<ul></ul>
-				</nav>
-			</div>
+			<nav data-autogenerate="true">
+				<ul></ul>
+			</nav>
 		</div>
 	</nav>
 


### PR DESCRIPTION
If you run the demo page on viewport larger than 1279, the sticky nav overlaps the content:

![current](https://user-images.githubusercontent.com/2272928/31313826-5740d8aa-abb4-11e7-8fcb-56e5649bbc5f.png)

Checked the showcase demo page (http://hugeinc.github.io/showcase/components/carousel/) and that problem is not present there. The difference is that, in that page the sticky nav does not have a "container".

![showcase](https://user-images.githubusercontent.com/2272928/31313832-8061fa34-abb4-11e7-8a74-8f4075067087.png)

This PR removes the div container to fix that alignment issue.